### PR TITLE
change baseURL

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 ######################## default configuration ####################
-baseURL = "https://getistio.netlify.app/"
+baseURL = "https://getistio-demo.netlify.app/"
 title = "Get Istio"
 # google analytics
 googleAnalytics = "" # example : UA-123-45


### PR DESCRIPTION
change baseURL to getistio-demo.netlify.app, so that the menu doesn't point to old staging website.

Signed-off-by: Adityo Pratomo <adityo@tetrate.io>