### PR TITLE
adjust homepage docs link

### DIFF
--- a/content/ecosystem-partners/_index.en.md
+++ b/content/ecosystem-partners/_index.en.md
@@ -6,6 +6,7 @@ description: "Take a look at GetIstio partners and see how they benefit from it.
 # type dont remove or customize
 type : "docs"
 weight: 6
+# set these 2 to make it featured in homepage
 featured: true
 featureOrder: 4
 ---

--- a/content/getistio-cli/_index.en.md
+++ b/content/getistio-cli/_index.en.md
@@ -6,6 +6,9 @@ description: "Learn more about GetIstio CLI, how to install and manage it."
 # type dont remove or customize
 type : "docs"
 weight: 1
+# set these 2 to make it featured in homepage
 featured: true
 featureOrder: 1
+# set alternate link for homepage
+altLink: "/getistio-cli/what-is-getistio"
 ---

--- a/content/getistio-cli/reference/_index.en.md
+++ b/content/getistio-cli/reference/_index.en.md
@@ -1,0 +1,7 @@
+---
+title: "Reference"
+date: 2018-12-29T11:02:05+06:00
+description: "Detailed information on GetIstio CLI commands"
+# type dont remove or customize
+type : "docs"
+---

--- a/content/istio-cheatsheet/_index.en.md
+++ b/content/istio-cheatsheet/_index.en.md
@@ -6,6 +6,7 @@ description: "Important commands that you'll need to manage your Istio."
 # type dont remove or customize
 type : "docs"
 weight: 5
+# set these 2 to make it featured in homepage
 featured: true
 featureOrder: 3
 ---

--- a/content/istio-tutorials/_index.en.md
+++ b/content/istio-tutorials/_index.en.md
@@ -6,6 +6,7 @@ description: "After you got Istio running, sharpen your Istio skill by following
 # type dont remove or customize
 type : "docs"
 weight: 4
+# set these 2 to make it featured in homepage
 featured: true
 featureOrder: 2
 ---

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -116,7 +116,11 @@
             <i class="card-icon {{ .Params.Icon }} mb-4"></i>
             <h3 class="card-title h4">{{ .Title }}</h3>
             <p class="card-text">{{ .Params.Description }}</p>
-            <a href="{{ .Permalink }}" class="stretched-link"></a>
+            {{ if (isset .Params "altlink") }}
+              <a href="{{ .Params.Altlink }}" class="stretched-link"></a>
+            {{ else }}  
+              <a href="{{ .Permalink }}" class="stretched-link"></a>
+            {{ end }}  
           </div>
         </div>
       </div>


### PR DESCRIPTION
Adjusts the homepage GetIstio CLI link to targets Overview page. This is achieved by adding a special frontmatter, so in case we want to direct the featured menu to a specific page, we can do so.

Signed-off-by: Adityo Pratomo <adityo@tetrate.io>
