### PR TITLE
Code copy button fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ hugo serve -D
 ```
 
 ## Adding Content
+
 All contents are written in markdown. You can add main category by creating a folder in `/content` directory. The main index page for that new category is a file named `_index.en.md` (for English page). To add child pages under that category, create additional folder in that category folder and add another `_index.en.md` file.
 
 As an example, to add a category named Installation, which contains 2 child pages named "Linux" and "MacOS", you need to add the following files and folders
@@ -26,6 +27,14 @@ As an example, to add a category named Installation, which contains 2 child page
 Take a look at other file in the `/content` directory to see example of required frontmatter.
 
 To add blog content, just add markdown file in `/content/blog` directory.
+
+### Adding Code Snippet
+
+To automatically add copy code button to a shell code snippet, specify sh as the language after the backticks in the code snippet. For example:
+
+```sh
+getistio version
+```
 
 ## Adding Event
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -108,6 +108,10 @@ $(document).on("turbolinks:load", preloader);
 		tabPane.addClass('active');
 	});
 
+   $("pre code.language-sh")
+     .parent()
+     .append('<span class="copy-to-clipboard">copy</span>');
+
   // sets button to "copied" after clicked
 	$('.copy-to-clipboard').click(function () {
 		$(this).html('copied');

--- a/assets/scss/_common.scss
+++ b/assets/scss/_common.scss
@@ -63,6 +63,12 @@ a:hover {
   color: $primary-color;
 }
 
+
+pre.language-sh, pre {
+  background-color: #f9f7f6 !important;
+  color: #272822 !important;
+}
+
 .slick-slide {
   outline: 0;
 }
@@ -518,10 +524,10 @@ button.btn {
     }
   }
   pre.home-code-snippet {
-    background: #1f3344;
+    background: #1f3344 !important;
   }
   pre code {
-    color: #e8b3b3;
+    color: #e8b3b3 !important;
   }
 }
 .link-blue {
@@ -591,6 +597,7 @@ pre {
     }
   }
 }
+
 
 // this is valid if we use asciinema player, not embedding from asciinema.org.
 // pre.asciinema-terminal {

--- a/content/getistio-cli/install-istio/_index.en.md
+++ b/content/getistio-cli/install-istio/_index.en.md
@@ -8,7 +8,7 @@ type : "docs"
 As explained earlier, GetIstio by default communicates to the cluster defined by your Kubernetes configuration. Please make sure you’re connected to the correct cluster before proceeding with the installation steps.
 
 The most common example is to install the demo profile of Istio, That can be done with following command:
-```
+```sh
 getistio istioctl install --set profile=demo
 ```
 
@@ -21,7 +21,7 @@ This will install the Istio demo profile with ["Istio core" "Istiod" "Ingress ga
 ✔ Egress gateways installed
 ✔ Installation complete </pre>
 After the previous step is completed, the validation can be done by confirming the GetIstio and Istio versions installed:
-```
+```sh
 getistio version
 ```
 Output:<pre>

--- a/content/istio-tutorials/install-skywalking/_index.en.md
+++ b/content/istio-tutorials/install-skywalking/_index.en.md
@@ -13,13 +13,14 @@ To highlight the essential integration steps:
 
 - Install getistio per [documentation](https://getistio.io/installing-getistio-cli)
 - Deploy Istio using getistio command and enable [Access Log Service (ALS)](https://www.envoyproxy.io/docs/envoy/latest/api-v2/service/accesslog/v2/als.proto) using the following command:
-```
+```sh
 getistio istioctl install --set profile=demo \
                --set meshConfig.enableEnvoyAccessLogService=true \
                --set meshConfig.defaultConfig.envoyAccessLogService.address=skywalking-oap.istio-system:11800
 ```
 - Label the application namespace with 
-```
+
+```sh
 kubectl label namespace <namespace> istio-injection=enabled
 ```
 - Deploy Apache SkyWaliking and the Application per the [blog post](https://skywalking.apache.org/blog/2020-12-03-obs-service-mesh-with-sw-and-als/)


### PR DESCRIPTION
This PR enables auto addition of copy button to relevant code snippets inside doc. All code snippet with the following format

```sh
example code
```

will automatically get copy button, so that the website visitor can use it to copy code. 

cc: @PetrMc @deva26 @mathetake 

Signed-off-by: Adityo Pratomo <adityo@tetrate.io>