### PR TITLE
fix event section behaviour in homepage

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -173,10 +173,10 @@
     <h4>Upcoming Community Events</h4>
     <span><a href="/community/event">See All Events →</a></span>
     </div>
-    <div class="row">
+    <div class="row overflow-auto flex-md-nowrap">
       {{ range .Site.Taxonomies.categories.event }}
       {{ if eq .Page.Params.pastEvent false }}
-        <div class="col-lg-4 col-md-4 col-sm-6 mb-4">
+        <div class="col-lg-4 col-md-6 col-sm-6 mb-4">
           <div class="card match-height event-card">
             <p class="event-date pb-2">{{ .Page.Params.eventDate }}<span><i class="ti-calendar"></i></span></p>
             <a href="{{ .Page.RelPermalink }}"><h5>{{ .Page.Title }}</h5></a>


### PR DESCRIPTION
This PR fixes https://github.com/tetratelabs/getistio.io/issues/41. So the plan to have top 3 closest events to be displayed, but the user can scroll to see more events. So all events can be seen in homepage.

Signed-off-by: Adityo Pratomo <adityo@tetrate.io>