### PR TITLE
adjusts docs content width for wider screen

### DIFF
--- a/assets/scss/_common.scss
+++ b/assets/scss/_common.scss
@@ -1,6 +1,7 @@
 $breakpoint-xs: 576px;
 $breakpoint-md: 768px;
 $breakpoint-xl: 1140px;
+$breakpoint-xxl: 1400px;
 
 body {
   background-color: $body-color;
@@ -62,7 +63,6 @@ select {
 a:hover {
   color: $primary-color;
 }
-
 
 pre.language-sh, pre {
   background-color: #f9f7f6 !important;
@@ -615,6 +615,12 @@ pre {
 // pre.asciinema-terminal {
 //   height: 32em !important;
 // }
+
+@media (min-width: $breakpoint-xxl) {
+  .docs-content {
+    max-width: 1320px;
+  }
+}
 
 @media (min-width: $breakpoint-md) and (max-width: $breakpoint-xl) {
   .hero-section {

--- a/layouts/partials/default.html
+++ b/layouts/partials/default.html
@@ -1,6 +1,6 @@
 {{ "<!-- details page -->" | safeHTML }}
 <section class="pt-5">
-  <div class="container shadow section-sm rounded">
+  <div class="container shadow section-sm rounded docs-content">
     <div class="row">
       <div class="col-lg-3 col-md-4 d-none d-md-block">
         <ul class="sidenav">
@@ -16,7 +16,7 @@
           {{ end }}
         </ul>
       </div>
-      <div class="col-md-8">
+      <div class="col-md-9">
         <div class="px-lg-5 px-4">
           <h2 class="mb-4 font-weight-medium">{{ .Title }}</h2>
           {{ if .Content }}


### PR DESCRIPTION
This PR adjusts the docs content width, specifically for wider screen. Previously, the max width is capped at 1140px, which looks kinda cluttered with too many white spaces in widescreen. Now, it's increased to 1320px, giving more room but still easy to read.

Signed-off-by: Adityo Pratomo <adityo@tetrate.io>