### PR TITLE
change pagination to use RelPermalink

### DIFF
--- a/layouts/partials/default.html
+++ b/layouts/partials/default.html
@@ -54,11 +54,11 @@
             {{ end }}
 
             {{with ($.Scratch.Get "prevPage")}}
-            <a class="nav nav-prev" href="{{.Permalink }}"><i class="ti-arrow-left mr-2"></i>
+            <a class="nav nav-prev" href="{{.RelPermalink }}"><i class="ti-arrow-left mr-2"></i>
               <span class="d-none d-md-block">{{.Title}}</span></a>
             {{end}}
             {{with ($.Scratch.Get "nextPage")}}
-            <a class="nav nav-next" href="{{.Permalink }}"> <span class="d-none d-md-block">{{.Title}}</span><i
+            <a class="nav nav-next" href="{{.RelPermalink }}"> <span class="d-none d-md-block">{{.Title}}</span><i
                 class="ti-arrow-right ml-2"></i></a>
             {{end}}
           </nav>


### PR DESCRIPTION
Previous docs content still use Permalink, switching it to relpermalink to fix 404 after the latest changes.

Signed-off-by: Adityo Pratomo <adityo@tetrate.io>