### PR TITLE
fix multilanguage

### DIFF
--- a/content/en/download/linux/index.md
+++ b/content/en/download/linux/index.md
@@ -5,4 +5,5 @@ weight: 5
 draft: false
 ---
 Below you can find direct URL for Istio and istioctl distros: 
-{{< dwn_linux >}}
+
+{{< downloads linux >}}

--- a/content/en/download/macos/index.md
+++ b/content/en/download/macos/index.md
@@ -6,4 +6,4 @@ draft: false
 ---
 Below you can find direct URL for Istio and istioctl distros:
 
-{{< dwn_macos >}}
+{{< downloads osx >}}

--- a/content/en/download/windows/index.md
+++ b/content/en/download/windows/index.md
@@ -7,5 +7,5 @@ draft: false
 
 Below you can find direct URL for Istio and istioctl distros:
 
-{{< dwn_windows >}}
+{{< downloads windows >}}
 

--- a/content/zh/community/building-and-testing/_index.md
+++ b/content/zh/community/building-and-testing/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Building and Testing"
-url: /community/building-and-testing
+url: /zh/community/building-and-testing
 ---
 
 Before you proceed, please make sure that you have the following dependencies available in your machine:

--- a/content/zh/community/contributing/_index.md
+++ b/content/zh/community/contributing/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Contributing to GetIstio"
-url: /community/contributing
+url: /zh/community/contributing
 ---
 
 We welcome contributions from the community. Please read the following guidelines carefully to maximize the chances of your PR being merged.

--- a/content/zh/community/release/_index.md
+++ b/content/zh/community/release/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Release process"
-url: /community/release
+url: /zh/community/release
 ---
 
 On any new release tag on this repository, our release workflow defined in `.github/workflows/release.yaml` 

--- a/content/zh/download/linux/index.md
+++ b/content/zh/download/linux/index.md
@@ -5,5 +5,6 @@ weight: 5
 draft: false
 ---
 以下是 Istio 和 istioctl 发行版的下载链接。
-{{< dwn_linux >}}
+
+{{< downloads linux >}}
 

--- a/content/zh/download/macos/index.md
+++ b/content/zh/download/macos/index.md
@@ -6,4 +6,4 @@ draft: false
 ---
 以下是 Istio 和 istioctl 发行版的下载链接。
 
-{{< dwn_macos >}}
+{{< downloads osx >}}

--- a/content/zh/download/windows/index.md
+++ b/content/zh/download/windows/index.md
@@ -7,5 +7,5 @@ draft: false
 
 以下是 Istio 和 istioctl 发行版的下载链接。
 
-{{< dwn_windows >}}
+{{< downloads windows >}}
 

--- a/content/zh/getistio-cli/reference/getistio/_index.md
+++ b/content/zh/getistio-cli/reference/getistio/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "getistio"
-url: /getistio-cli/reference/getistio/
+url: /zh/getistio-cli/reference/getistio/
 ---
 
 GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.

--- a/content/zh/getistio-cli/reference/getistio/_index.md
+++ b/content/zh/getistio-cli/reference/getistio/_index.md
@@ -14,15 +14,15 @@ GetIstio is an integration and lifecycle management CLI tool that ensures the us
 
 #### SEE ALSO
 
-* [getistio check-upgrade](/getistio-cli/reference/getistio_check-upgrade/)	 - Check if there are patches available in the current minor version
-* [getistio config-validate](/getistio-cli/reference/getistio_config-validate/)	 - Validate the current Istio configurations in your cluster
-* [getistio fetch](/getistio-cli/reference/getistio_fetch/)	 - Fetch istioctl of the specified version, flavor and flavor-version available in "getistio list" command
-* [getistio gen-ca](/getistio-cli/reference/getistio_gen-ca/)	 - Generate intermediate CA
-* [getistio istioctl](/getistio-cli/reference/getistio_istioctl/)	 - Execute istioctl with given arguments
-* [getistio list](/getistio-cli/reference/getistio_list/)	 - List available Istio distributions built by Tetrate
-* [getistio prune](/getistio-cli/reference/getistio_prune/)	 - Remove specific istioctl installed, or all, except the active one 
-* [getistio show](/getistio-cli/reference/getistio_show/)	 - Show fetched Istio versions
-* [getistio switch](/getistio-cli/reference/getistio_switch/)	 - Switch the active istioctl to a specified version
-* [getistio update](/getistio-cli/reference/getistio_update/)	 - Update getistio itself to the latest version
-* [getistio version](/getistio-cli/reference/getistio_version/)	 - Show the versions of GetIstio running Istiod, Envoy, and the active istioctl's path
+* [getistio check-upgrade](/zh/getistio-cli/reference/getistio_check-upgrade/)	 - Check if there are patches available in the current minor version
+* [getistio config-validate](/zh/getistio-cli/reference/getistio_config-validate/)	 - Validate the current Istio configurations in your cluster
+* [getistio fetch](/zh/getistio-cli/reference/getistio_fetch/)	 - Fetch istioctl of the specified version, flavor and flavor-version available in "getistio list" command
+* [getistio gen-ca](/zh/getistio-cli/reference/getistio_gen-ca/)	 - Generate intermediate CA
+* [getistio istioctl](/zh/getistio-cli/reference/getistio_istioctl/)	 - Execute istioctl with given arguments
+* [getistio list](/zh/getistio-cli/reference/getistio_list/)	 - List available Istio distributions built by Tetrate
+* [getistio prune](/zh/getistio-cli/reference/getistio_prune/)	 - Remove specific istioctl installed, or all, except the active one 
+* [getistio show](/zh/getistio-cli/reference/getistio_show/)	 - Show fetched Istio versions
+* [getistio switch](/zh/getistio-cli/reference/getistio_switch/)	 - Switch the active istioctl to a specified version
+* [getistio update](/zh/getistio-cli/reference/getistio_update/)	 - Update getistio itself to the latest version
+* [getistio version](/zh/getistio-cli/reference/getistio_version/)	 - Show the versions of GetIstio running Istiod, Envoy, and the active istioctl's path
 

--- a/content/zh/getistio-cli/reference/getistio_check-upgrade/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_check-upgrade/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "getistio check-upgrade"
-url: /getistio-cli/reference/getistio_check-upgrade/
+url: /zh/getistio-cli/reference/getistio_check-upgrade/
 ---
 
 Check if there are patches available in the current minor version, e.g. 1.7-tetrate: 1.7.4-tetrate-v1 -> 1.7.5-tetrate-v1

--- a/content/zh/getistio-cli/reference/getistio_check-upgrade/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_check-upgrade/_index.md
@@ -39,5 +39,5 @@ Please refer to 'getistio fetch --help' or 'getistio list --help' for more infor
 
 #### SEE ALSO
 
-* [getistio](/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
+* [getistio](/zh/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
 

--- a/content/zh/getistio-cli/reference/getistio_config-validate/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_config-validate/_index.md
@@ -79,5 +79,5 @@ The error code of the found issue which is prefixed by 'IST' or 'KIA'. Please re
 
 #### SEE ALSO
 
-* [getistio](/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
+* [getistio](/zh/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
 

--- a/content/zh/getistio-cli/reference/getistio_config-validate/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_config-validate/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "getistio config-validate"
-url: /getistio-cli/reference/getistio_config-validate/
+url: /zh/getistio-cli/reference/getistio_config-validate/
 ---
 
 Validate the current Istio configurations in your cluster just like 'istioctl analyze'. Inspect all namespaces by default.

--- a/content/zh/getistio-cli/reference/getistio_fetch/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_fetch/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "getistio fetch"
-url: /getistio-cli/reference/getistio_fetch/
+url: /zh/getistio-cli/reference/getistio_fetch/
 ---
 
 Fetch istioctl of the specified version, flavor and flavor-version available in "getistio list" command

--- a/content/zh/getistio-cli/reference/getistio_fetch/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_fetch/_index.md
@@ -63,5 +63,5 @@ For more information, please refer to "getistio list --help" command.
 
 #### SEE ALSO
 
-* [getistio](/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
+* [getistio](/zh/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
 

--- a/content/zh/getistio-cli/reference/getistio_gen-ca/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_gen-ca/_index.md
@@ -43,5 +43,5 @@ getistio gen-ca [flags]
 
 #### SEE ALSO
 
-* [getistio](/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
+* [getistio](/zh/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
 

--- a/content/zh/getistio-cli/reference/getistio_gen-ca/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_gen-ca/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "getistio gen-ca"
-url: /getistio-cli/reference/getistio_gen-ca/
+url: /zh/getistio-cli/reference/getistio_gen-ca/
 ---
 
 Generates Intermediate CA from different managed services such as AWS ACMPCA, GCP CAS

--- a/content/zh/getistio-cli/reference/getistio_help/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_help/_index.md
@@ -24,5 +24,5 @@ getistio help [command] [flags]
 
 #### SEE ALSO
 
-* [getistio](/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
+* [getistio](/zh/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
 

--- a/content/zh/getistio-cli/reference/getistio_help/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_help/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "getistio help"
-url: /getistio-cli/reference/getistio_help/
+url: /zh/getistio-cli/reference/getistio_help/
 ---
 
 Help provides help for any command in the application.

--- a/content/zh/getistio-cli/reference/getistio_istioctl/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_istioctl/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "getistio istioctl"
-url: /getistio-cli/reference/getistio_istioctl/
+url: /zh/getistio-cli/reference/getistio_istioctl/
 ---
 
 Execute istioctl with given arguments where the version of istioctl is specified at ~/.getistio/config.json.

--- a/content/zh/getistio-cli/reference/getistio_istioctl/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_istioctl/_index.md
@@ -33,5 +33,5 @@ getistio istioctl version
 
 #### SEE ALSO
 
-* [getistio](/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
+* [getistio](/zh/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
 

--- a/content/zh/getistio-cli/reference/getistio_list/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_list/_index.md
@@ -58,5 +58,5 @@ Supported k8s versions for the distribution
 
 #### SEE ALSO
 
-* [getistio](/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
+* [getistio](/zh/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
 

--- a/content/zh/getistio-cli/reference/getistio_list/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_list/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "getistio list"
-url: /getistio-cli/reference/getistio_list/
+url: /zh/getistio-cli/reference/getistio_list/
 ---
 
 List available Istio distributions built by Tetrate

--- a/content/zh/getistio-cli/reference/getistio_prune/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_prune/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "getistio prune"
-url: /getistio-cli/reference/getistio_prune/
+url: /zh/getistio-cli/reference/getistio_prune/
 ---
 
 Remove all or a specific istioctl installed except the active one

--- a/content/zh/getistio-cli/reference/getistio_prune/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_prune/_index.md
@@ -37,5 +37,5 @@ $ getistio prune --version 1.7.4 --flavor tetrate --flavor-version 0
 
 #### SEE ALSO
 
-* [getistio](/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
+* [getistio](/zh/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
 

--- a/content/zh/getistio-cli/reference/getistio_show/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_show/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "getistio show"
-url: /getistio-cli/reference/getistio_show/
+url: /zh/getistio-cli/reference/getistio_show/
 ---
 
 Show fetched Istio version

--- a/content/zh/getistio-cli/reference/getistio_show/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_show/_index.md
@@ -29,5 +29,5 @@ getistio show
 
 #### SEE ALSO
 
-* [getistio](/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
+* [getistio](/zh/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
 

--- a/content/zh/getistio-cli/reference/getistio_switch/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_switch/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "getistio switch"
-url: /getistio-cli/reference/getistio_switch/
+url: /zh/getistio-cli/reference/getistio_switch/
 ---
 
 Switch the active istioctl to the one of the specified version

--- a/content/zh/getistio-cli/reference/getistio_switch/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_switch/_index.md
@@ -33,5 +33,5 @@ $ getistio switch --version 1.7.4 --flavor tetrate --flavor-version=1
 
 #### SEE ALSO
 
-* [getistio](/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
+* [getistio](/zh/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
 

--- a/content/zh/getistio-cli/reference/getistio_update/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_update/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "getistio update"
-url: /getistio-cli/reference/getistio_update/
+url: /zh/getistio-cli/reference/getistio_update/
 ---
 
 Update getistio itself to the latest version

--- a/content/zh/getistio-cli/reference/getistio_update/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_update/_index.md
@@ -23,5 +23,5 @@ getistio update [flags]
 
 #### SEE ALSO
 
-* [getistio](/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
+* [getistio](/zh/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
 

--- a/content/zh/getistio-cli/reference/getistio_version/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_version/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "getistio version"
-url: /getistio-cli/reference/getistio_version/
+url: /zh/getistio-cli/reference/getistio_version/
 ---
 
 Show the versions of GetIstio running Istiod, Envoy, and the active istioctl's path

--- a/content/zh/getistio-cli/reference/getistio_version/_index.md
+++ b/content/zh/getistio-cli/reference/getistio_version/_index.md
@@ -24,5 +24,5 @@ getistio version [flags]
 
 #### SEE ALSO
 
-* [getistio](/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
+* [getistio](/zh/getistio-cli/reference/getistio/)	 - GetIstio is an integration and lifecycle management CLI tool that ensures the use of supported and trusted versions of Istio.
 


### PR DESCRIPTION
This PR fixes https://github.com/tetratelabs/getistio.io/issues/76 and addresses the broken link issued in https://github.com/tetratelabs/getistio.io/pull/70#issuecomment-773414354

Basically, for content files in `/zh` directory that has url, whether it's in frontmatter or in link, make sure that the url is prepennded with  `/zh/` to ensure that the file is correctly processed by hugo and put in the correct directory.

Example:

In the file: `content/zh/getistio-cli/reference/getistio_list/_index.md`

make sure that the frontmatter looks like this:

```
---
title: "getistio list"
url: /zh/getistio-cli/reference/getistio_list/
---
```

note the `/zh/` in front of URL.

Signed-off-by: Adityo Pratomo <adityo@tetrate.io>
